### PR TITLE
Workarounds for team id inconsistency

### DIFF
--- a/grafana_backup/constants.py
+++ b/grafana_backup/constants.py
@@ -7,5 +7,5 @@ else:
     homedir = os.environ["HOME"]
 
 PKG_NAME = "grafana-backup"
-PKG_VERSION = "1.2.4"
+PKG_VERSION = "1.2.5"
 JSON_CONFIG_PATH = "{0}/.grafana-backup.json".format(homedir)

--- a/grafana_backup/constants.py
+++ b/grafana_backup/constants.py
@@ -7,5 +7,5 @@ else:
     homedir = os.environ["HOME"]
 
 PKG_NAME = "grafana-backup"
-PKG_VERSION = "1.2.3"
+PKG_VERSION = "1.2.4"
 JSON_CONFIG_PATH = "{0}/.grafana-backup.json".format(homedir)

--- a/grafana_backup/create_team_member.py
+++ b/grafana_backup/create_team_member.py
@@ -1,12 +1,13 @@
 import json
 import urllib.parse
 
-from grafana_backup.dashboardApi import create_team_member, get_user_by_email_or_username
+from grafana_backup.dashboardApi import create_team_member, get_user_by_email_or_username, get_team_by_name
 
 
 def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
+    http_get_headers = settings.get('HTTP_GET_HEADERS')
     http_get_headers_basic_auth = settings.get('HTTP_GET_HEADERS_BASIC_AUTH')
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
@@ -17,6 +18,20 @@ def main(args, settings, file_path):
             data = f.read()
 
         team_member = json.loads(data)
+
+        # PROBLEM:
+        # 1. grafana_backup can't create team with same id as in backup (api limitations)
+        # 2. grafana uses only team id to add team member
+        # That's means impossibility to use api export + import without workarounds
+        # WORKAROUND:
+        # Find the real team id by name before adding a user
+        # See save_team_members.py for details
+        if 'teamName' in team_member:
+            result = get_team_by_name(team_member['teamName'], grafana_url,
+                                      http_get_headers, verify_ssl, client_cert, debug)
+            if result > 0:
+                team_member['teamId'] = result
+
         # A Team-Membership is a connection between a user and a team. However, userIds are not unique across Grafana
         # instances. Therefore, we need to first find the user id by the email.
         user_id = get_user_by_email_or_username(urllib.parse.quote(team_member['email']), grafana_url,
@@ -30,7 +45,7 @@ def main(args, settings, file_path):
 
         user = json.dumps({"userId": user_id[1]['id']})
         result = create_team_member(user, team_member['teamId'], grafana_url, http_post_headers, verify_ssl,
-                                        client_cert, debug)
+                                    client_cert, debug)
         print("create team member: {0}, status: {1}, msg: {2}".format(team_member['name'], result[0], result[1]))
     else:
         print('[ERROR] Restoring team members needs to set GRAFANA_ADMIN_ACCOUNT and GRAFANA_ADMIN_PASSWORD first. \n')

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -1,9 +1,9 @@
 import re
 import json
 import requests
+import urllib.parse
 import sys
 from grafana_backup.commons import log_response, to_python2_and_3_compatible_string
-
 
 def health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     url = '{0}/api/health'.format(grafana_url)
@@ -126,6 +126,21 @@ def search_teams(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
     print("search teams in grafana: {0}".format(url))
     return send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
 
+
+def get_team_by_name(name, grafana_url, http_get_headers, verify_ssl, client_cert, debug):
+    response = send_grafana_get('{0}/api/teams/search?name={1}'.format(grafana_url, urllib.parse.quote(name)),
+                                http_get_headers, verify_ssl, client_cert, debug)
+    if isinstance(response[1], dict):
+        teams = response[1]
+    else:
+        teams = json.loads(response[1])
+    try:
+        for team in teams['teams']:
+            if team['name'] == name:
+                return team['id']
+    except KeyError:
+        return 0
+    return 0
 
 def create_team(team, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
     url = '{0}/api/teams'.format(grafana_url)

--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -318,13 +318,14 @@ def update_folder_permissions(payload, grafana_url, http_post_headers, verify_ss
 
 def get_folder_id(dashboard, grafana_url, http_post_headers, verify_ssl, client_cert, debug):
     folder_uid = ""
-    try:
+    if 'folderUid' in dashboard['meta'].keys():
         folder_uid = dashboard['meta']['folderUid']
-    except (KeyError):
+    if folder_uid == "":
         matches = re.search('dashboards\/f\/(.*)\/.*', dashboard['meta']['folderUrl'])
-        folder_uid = matches.group(1)
+        if matches is not None:
+            folder_uid = matches.group(1)
 
-    if (folder_uid != ""):
+    if folder_uid != "":
         print("debug: quering with uid {}".format(folder_uid))
         response = get_folder(folder_uid, grafana_url, http_post_headers, verify_ssl, client_cert, debug)
         if isinstance(response[1], dict):
@@ -337,6 +338,8 @@ def get_folder_id(dashboard, grafana_url, http_post_headers, verify_ssl, client_
         except (KeyError):
             return 0
     else:
+        if 'folderId' in dashboard['meta'].keys():
+            return dashboard['meta']['folderId']
         return 0
 
 

--- a/grafana_backup/delete.py
+++ b/grafana_backup/delete.py
@@ -14,9 +14,9 @@ import sys
 def main(args, settings):
     arg_components = args.get('--components', False)
 
-    # Backups, saved in grafana-backup version < 1.2.4 do not contain enough data for correct restoring of team-members
+    # Backups, saved in grafana-backup version < 1.2.5 do not contain enough data for correct restoring of team-members
     # Therefore, teams removal is disabled by default
-    # But can be called explicitly if you SURE that backup for team-members created in 1.2.4+
+    # But can be called explicitly if you SURE that backup for team-members created in 1.2.5+
     delete_functions = {'dashboards': delete_dashboards,
                         'datasources': delete_datasources,
                         'folders': delete_folders,

--- a/grafana_backup/delete.py
+++ b/grafana_backup/delete.py
@@ -7,14 +7,16 @@ from grafana_backup.delete_alert_channels import main as delete_alert_channels
 from grafana_backup.delete_snapshots import main as delete_snapshots
 from grafana_backup.delete_annotations import main as delete_annotations
 from grafana_backup.delete_team_members import main as delete_team_members
+from grafana_backup.delete_teams import main as delete_teams
 import sys
 
 
 def main(args, settings):
     arg_components = args.get('--components', False)
 
-    # By default, teams should not be deleted. Sinces teams don't have unique ids across instances, they would be
-    # recreated with different ids, therefore loosing references to folder permissions and team members.
+    # Backups, saved in grafana-backup version < 1.2.4 do not contain enough data for correct restoring of team-members
+    # Therefore, teams removal is disabled by default
+    # But can be called explicitly if you SURE that backup for team-members created in 1.2.4+
     delete_functions = {'dashboards': delete_dashboards,
                         'datasources': delete_datasources,
                         'folders': delete_folders,
@@ -40,7 +42,10 @@ def main(args, settings):
 
         # Delete only the components that provided via an argument
         for delete_function in arg_components_list:
-            delete_functions[delete_function](args, settings)
+            if delete_function == 'teams':
+                delete_teams(args, settings)
+            else:
+                delete_functions[delete_function](args, settings)
     else:
         # delete every component
         for delete_function in delete_functions.keys():

--- a/grafana_backup/save_team_members.py
+++ b/grafana_backup/save_team_members.py
@@ -64,6 +64,10 @@ def get_individual_team_members_and_save(teams, folder_path, log_file, pretty_pr
                                                                client_cert, debug):
                     team_member_identifier = "{0}_{1}".format(team_member['userId'], team_member['teamId'])
 
+                    # Explicitly saving of team name to correctly restore team members
+                    # See create_team_member.py for details
+                    team_member['teamName'] = to_python2_and_3_compatible_string(team['name'])
+
                     save_team_member(
                         to_python2_and_3_compatible_string(team['name']),
                         to_python2_and_3_compatible_string(str(team_member_identifier)),

--- a/grafana_backup/update_folder_permissions.py
+++ b/grafana_backup/update_folder_permissions.py
@@ -1,10 +1,11 @@
 import json
-from grafana_backup.dashboardApi import update_folder_permissions
+from grafana_backup.dashboardApi import update_folder_permissions, get_team_by_name
 
 
 def main(args, settings, file_path):
     grafana_url = settings.get('GRAFANA_URL')
     http_post_headers = settings.get('HTTP_POST_HEADERS')
+    http_get_headers = settings.get('HTTP_GET_HEADERS')
     verify_ssl = settings.get('VERIFY_SSL')
     client_cert = settings.get('CLIENT_CERT')
     debug = settings.get('DEBUG')
@@ -14,5 +15,18 @@ def main(args, settings, file_path):
 
     folder_permissions = json.loads(data)
     if folder_permissions:
+        # PROBLEM:
+        # 1. grafana_backup can't create team with same id as in backup (api limitations)
+        # 2. grafana uses only team id to update folder permissions
+        # That's means impossibility to use api export + import without workarounds
+        # WORKAROUND:
+        # Find the real team id by name before updating folder permissions
+        for fp in folder_permissions:
+            if fp['teamId'] > 0:
+                result = get_team_by_name(fp['team'], grafana_url,
+                                          http_get_headers, verify_ssl, client_cert, debug)
+                if result > 0:
+                    fp['teamId'] = result
+
         result = update_folder_permissions(folder_permissions, grafana_url, http_post_headers, verify_ssl, client_cert, debug)
         print("update folder permissions {0}, status: {1}, msg: {2}\n".format(folder_permissions[0].get('title', ''), result[0], result[1]))


### PR DESCRIPTION
Hello!

PROBLEM:
1. grafana-backup-tool can't create team with same id as in backup (api limitations)
2. grafana uses only team id to add team member and folder permissions
That's means impossibility to use api export + import without workarounds

WORKAROUND:
Find the real team id by name before adding a user

Thanks for your improvements to grafana-backup-tool!